### PR TITLE
Implement headers interface

### DIFF
--- a/__tests__/axios-api.test.ts
+++ b/__tests__/axios-api.test.ts
@@ -72,7 +72,7 @@ describe("Axios API Client Retry Logic", () => {
   it("should be able to retry a request", async () => {
     nock(TEST_URL).get("/posts/1").times(4).reply(502)
 
-    const client = new AxiosApiClient(TEST_URL, undefined, undefined, undefined, (retryCount) => {
+    const client = new AxiosApiClient(TEST_URL, undefined, undefined, undefined, undefined, (retryCount) => {
       console.log(retryCount)
     })
     const spy = jest.spyOn(console, "log")
@@ -83,5 +83,118 @@ describe("Axios API Client Retry Logic", () => {
       expect(spy).toHaveBeenCalledWith(2)
       expect(spy).toHaveBeenCalledWith(3)
     }).rejects.toThrow(new AxiosError("Request failed with status code 502"))
+  })
+})
+
+describe("Axios API Client Headers Interface", () => {
+  it("should set headers correctly when initialized with axios instance", async () => {
+    const client = new AxiosApiClient(TEST_URL, {
+      "Content-Type": "application/json",
+      Authorization: "Bearer token",
+    })
+
+    nock(TEST_URL, {
+      reqheaders: {
+        "Content-Type": (headerValue) => headerValue === "application/json",
+        Authorization: (headerValue) => headerValue === "Bearer token",
+      },
+    })
+      .get("/posts/1")
+      .reply(200, { id: 1 })
+
+    const result = await client.get("/posts/1")
+    expect(result.status).toBe(200)
+    expect(result.data).toBeDefined()
+    expect(result.data).toHaveProperty("id")
+  })
+
+  it("should set headers correctly when configured at request level", async () => {
+    const client = new AxiosApiClient(TEST_URL)
+
+    nock(TEST_URL, {
+      reqheaders: {
+        "Content-Type": (headerValue) => headerValue === "application/json",
+        Authorization: (headerValue) => headerValue === "Bearer token",
+      },
+    })
+      .get("/posts/1")
+      .reply(200, { id: 1 })
+
+    const result = await client.get("/posts/1", {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer token",
+      },
+    })
+    expect(result.status).toBe(200)
+    expect(result.data).toBeDefined()
+    expect(result.data).toHaveProperty("id")
+  })
+
+  it("setHeader method should set headers on axios instance", async () => {
+    const client = new AxiosApiClient(TEST_URL)
+
+    nock(TEST_URL, {
+      reqheaders: {
+        "Content-Type": (headerValue) => headerValue === "application/json",
+        Authorization: (headerValue) => headerValue === "Bearer token",
+      },
+    })
+      .get("/posts/1")
+      .reply(200, { id: 1 })
+
+    client.setHeader("Content-Type", "application/json")
+    client.setHeader("Authorization", "Bearer token")
+
+    const result = await client.get("/posts/1")
+    expect(result.status).toBe(200)
+    expect(result.data).toBeDefined()
+    expect(result.data).toHaveProperty("id")
+  })
+
+  it("setHeader method should override default headers set", async () => {
+    const client = new AxiosApiClient(TEST_URL, {
+      "Content-Type": "application/json",
+      Authorization: "Bearer token",
+    })
+
+    nock(TEST_URL, {
+      reqheaders: {
+        "Content-Type": (headerValue) => headerValue === "application/xml",
+        Authorization: (headerValue) => headerValue === "Bearer token",
+      },
+    })
+      .get("/posts/1")
+      .reply(200, { id: 1 })
+
+    client.setHeader("Content-Type", "application/xml")
+
+    const result = await client.get("/posts/1")
+    expect(result.status).toBe(200)
+    expect(result.data).toBeDefined()
+    expect(result.data).toHaveProperty("id")
+  })
+
+  it("request level headers should override default headers set", async () => {
+    const client = new AxiosApiClient(TEST_URL, {
+      "Content-Type": "application/json",
+    })
+
+    nock(TEST_URL, {
+      reqheaders: {
+        "Content-Type": (headerValue) => headerValue === "application/xml",
+      },
+    })
+      .get("/posts/1")
+      .reply(200, { id: 1 })
+
+    const result = await client.get("/posts/1", {
+      headers: {
+        "Content-Type": "application/xml",
+      },
+    })
+    expect(result.status).toBe(200)
+    expect(result.data).toBeDefined()
+    expect(result.data).toHaveProperty("id")
   })
 })

--- a/src/AxiosApiClient.ts
+++ b/src/AxiosApiClient.ts
@@ -1,12 +1,37 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios"
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios"
 
 import axiosRetry from "axios-retry"
+import { Headers, IHttpHeaders } from "./headers"
 
-export class AxiosApiClient {
+class AxiosHeaders implements IHttpHeaders {
+  headers: Headers = {}
+
+  constructor(headers?: Headers) {
+    if (headers) {
+      this.headers = headers
+    }
+  }
+
+  set(name: string, value: string): void {
+    this.headers[name] = value
+  }
+
+  get(name: string) {
+    return this.headers[name]
+  }
+
+  append(headers: Headers): void {
+    this.headers = { ...this.headers, ...headers }
+  }
+}
+
+class AxiosApiClient {
   private instance: AxiosInstance
+  private headers: AxiosHeaders = new AxiosHeaders()
 
   constructor(
     baseUrl: string,
+    headers?: Headers,
     timeout: number = 30000,
     retries: number = 3,
     retryDelay?: (retryCount: number) => number,
@@ -15,8 +40,11 @@ export class AxiosApiClient {
     this.instance = axios.create({
       baseURL: baseUrl,
       timeout,
+      headers,
     })
-
+    if (headers) {
+      this.headers.append(headers)
+    }
     axiosRetry(this.instance, { retries, retryDelay, onRetry })
   }
 
@@ -24,23 +52,39 @@ export class AxiosApiClient {
     return this.instance
   }
 
+  private setConfigRequestHeaders(config?: AxiosRequestConfig) {
+    const headers = { ...this.headers.headers, ...config?.headers }
+    return { ...config, headers }
+  }
+
+  setHeader(name: string, value: string): void {
+    this.headers.set(name, value)
+  }
+
   async get<T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    config = this.setConfigRequestHeaders(config)
     return this.instance.get(url, config)
   }
 
   async post<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    config = this.setConfigRequestHeaders(config)
     return this.instance.post(url, data, config)
   }
 
   async put<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    config = this.setConfigRequestHeaders(config)
     return this.instance.put(url, data, config)
   }
 
   async patch<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    config = this.setConfigRequestHeaders(config)
     return await this.instance.patch(url, data, config)
   }
 
   async delete<T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    config = this.setConfigRequestHeaders(config)
     return this.instance.delete(url, config)
   }
 }
+
+export { AxiosApiClient, type AxiosError }

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,15 @@
+type Headers = {
+  [key: string]: string | number | boolean
+}
+
+interface IHttpHeaders {
+  headers?: Headers
+
+  set(name: string, value: string): void
+
+  get(name: string): void
+
+  append(headers: Headers): void
+}
+
+export { type Headers, type IHttpHeaders }


### PR DESCRIPTION
This pull request implements the headers interface for the Axios API client. It introduces a new class called AxiosHeaders that handles setting and getting headers for requests. The AxiosApiClient class has been updated to use AxiosHeaders for managing headers.

The changes in this pull request allow users to set headers when initializing the Axios API client, at the request level, or using the new setHeader method. The setHeader method can be used to override default headers set at the client level.
