### PR TITLE
chore(deps): upgrade all packages to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akadenia/api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akadenia/api",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.6",


### PR DESCRIPTION
## Summary

- Ran `ncu -u` to check for available dependency upgrades
- All dependencies were already at their latest compatible versions
- **typescript** `^5.9.2` → `^6.0.2` was the only candidate but was **reverted** because `ts-jest@29` has a peer dependency requiring `typescript >=4.3 <6`
- Synced `package-lock.json` version field (1.1.0 → 1.2.0) to match `package.json`

## Skipped upgrades

| Package | Current | Latest | Reason |
|---------|---------|--------|--------|
| typescript | ^5.9.2 | ^6.0.2 | Blocked by ts-jest@29 peer dep (`<6`) |

## Test plan

- [x] `npm test` — all 23 tests passing
- [x] `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)