### PR TITLE
feat(client): add head, options and removeHeader methods

### DIFF
--- a/__tests__/axios-api.test.ts
+++ b/__tests__/axios-api.test.ts
@@ -77,6 +77,24 @@ describe("Axios API Client Methods", () => {
     expect(result.success).toBe(true)
     expect(result.status).toBe(200)
   })
+
+  it("should be able to execute a HEAD request to a server", async () => {
+    nock(FAKE_API_URL).head("/posts/1").reply(200, "", { "x-custom": "value" })
+
+    const client = new AxiosApiClient({ baseUrl: FAKE_API_URL })
+    const result = await client.head("/posts/1")
+    expect(result.success).toBe(true)
+    expect(result.status).toBe(200)
+  })
+
+  it("should be able to execute an OPTIONS request to a server", async () => {
+    nock(FAKE_API_URL).options("/posts/1").reply(204, "", { allow: "GET,POST,OPTIONS" })
+
+    const client = new AxiosApiClient({ baseUrl: FAKE_API_URL })
+    const result = await client.options("/posts/1")
+    expect(result.success).toBe(true)
+    expect(result.status).toBe(204)
+  })
 })
 
 describe("Axios API Client Retry Logic", () => {
@@ -211,6 +229,29 @@ describe("Axios API Client Headers Interface", () => {
       .reply(200, { id: 1 })
 
     client.setHeader("Content-Type", "application/xml")
+
+    const result = await client.get("/posts/1")
+    expect(result.status).toBe(200)
+    expect(result.data).toBeDefined()
+    expect(result.data).toHaveProperty("id")
+  })
+
+  it("removeHeader method should remove a previously set header", async () => {
+    const client = new AxiosApiClient({
+      baseUrl: FAKE_API_URL,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer token",
+      },
+    })
+
+    nock(FAKE_API_URL, {
+      badheaders: ["Authorization"],
+    })
+      .get("/posts/1")
+      .reply(200, { id: 1 })
+
+    client.removeHeader("Authorization")
 
     const result = await client.get("/posts/1")
     expect(result.status).toBe(200)

--- a/src/AxiosApiClient.ts
+++ b/src/AxiosApiClient.ts
@@ -77,9 +77,26 @@ class AxiosApiClient {
     this.headers.set(name, value)
   }
 
+  removeHeader(name: string): void {
+    this.headers.remove(name)
+    const defaults = this.instance.defaults.headers
+    delete defaults.common[name]
+    delete (defaults as Record<string, any>)[name]
+  }
+
   async get<T>(url: string, config?: AxiosRequestConfig): Promise<AkadeniaApiResponse<T>> {
     config = this.setConfigRequestHeaders(config)
     return this.instance.get(url, config)
+  }
+
+  async head<T>(url: string, config?: AxiosRequestConfig): Promise<AkadeniaApiResponse<T>> {
+    config = this.setConfigRequestHeaders(config)
+    return this.instance.head(url, config)
+  }
+
+  async options<T>(url: string, config?: AxiosRequestConfig): Promise<AkadeniaApiResponse<T>> {
+    config = this.setConfigRequestHeaders(config)
+    return this.instance.options(url, config)
   }
 
   async post<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AkadeniaApiResponse<T>> {

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -9,6 +9,8 @@ interface IHttpHeaders {
 
   get(name: string): void
 
+  remove(name: string): void
+
   append(headers: HeadersType): void
 }
 
@@ -27,6 +29,10 @@ class Headers implements IHttpHeaders {
 
   get(name: string) {
     return this.headers[name]
+  }
+
+  remove(name: string): void {
+    delete this.headers[name]
   }
 
   append(headers: HeadersType): void {


### PR DESCRIPTION
## Summary
- Add `removeHeader(name)` to `AxiosApiClient` and a corresponding `remove(name)` on `Headers` so callers can drop a previously set default header. Also clears the underlying axios instance defaults so the header does not leak back via `instance.defaults.headers`.
- Add `head()` and `options()` HTTP methods that mirror the existing request methods (header merging, retry/interceptor behaviour).
- Tests cover all three new behaviors.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (26/26 pass, 3 new tests added)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP HEAD and OPTIONS methods to the API client
  * Added ability to remove previously set custom headers from API requests

* **Tests**
  * Added tests covering HEAD and OPTIONS responses and status handling
  * Added tests verifying header removal prevents sending removed headers and that subsequent requests succeed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->