### PR TITLE
feat(client): add onRequest and onRequestError interceptor callbacks

### DIFF
--- a/__tests__/axios-api.test.ts
+++ b/__tests__/axios-api.test.ts
@@ -246,6 +246,83 @@ describe("Axios API Client Headers Interface", () => {
   })
 })
 
+describe("Axios API Client Request Interceptors", () => {
+  it("should invoke onRequest before the request is sent", async () => {
+    nock(FAKE_API_URL).get("/posts/1").reply(200, { id: 1 })
+
+    const onRequestSpy = jest.fn((config: any) => config)
+    const client = new AxiosApiClient({ baseUrl: FAKE_API_URL, onRequest: onRequestSpy })
+
+    const result = await client.get("/posts/1")
+
+    expect(result.success).toBe(true)
+    expect(onRequestSpy).toHaveBeenCalledTimes(1)
+    const passed = onRequestSpy.mock.calls[0][0] as any
+    expect(passed.url).toBe("/posts/1")
+    expect(passed.method).toBe("get")
+  })
+
+  it("should allow onRequest to mutate request config (e.g. add a header)", async () => {
+    nock(FAKE_API_URL, {
+      reqheaders: {
+        "X-Injected": (headerValue) => headerValue === "yes",
+      },
+    })
+      .get("/posts/1")
+      .reply(200, { id: 1 })
+
+    const client = new AxiosApiClient({
+      baseUrl: FAKE_API_URL,
+      onRequest: (config) => {
+        config.headers.set("X-Injected", "yes")
+        return config
+      },
+    })
+
+    const result = await client.get("/posts/1")
+    expect(result.status).toBe(200)
+  })
+
+  it("should invoke onRequestError when an upstream request interceptor rejects", async () => {
+    const onRequestErrorSpy = jest.fn((error: unknown) => Promise.reject(error))
+    const client = new AxiosApiClient({
+      baseUrl: FAKE_API_URL,
+      retries: 0,
+      onRequest: (config) => config,
+      onRequestError: onRequestErrorSpy,
+    })
+
+    // Register a second interceptor that runs *before* our onRequest pair
+    // (axios request interceptors run LIFO), so its rejection bubbles into
+    // our onRequestError handler.
+    client.getInstance().interceptors.request.use(() => {
+      throw new Error("boom")
+    })
+
+    const result = await client.get("/posts/1")
+
+    expect(result.success).toBe(false)
+    expect(onRequestErrorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("should invoke onRequestError when onRequest itself throws", async () => {
+    const onRequestErrorSpy = jest.fn((error: unknown) => Promise.reject(error))
+    const client = new AxiosApiClient({
+      baseUrl: FAKE_API_URL,
+      retries: 0,
+      onRequest: () => {
+        throw new Error("onRequest boom")
+      },
+      onRequestError: onRequestErrorSpy,
+    })
+
+    const result = await client.get("/posts/1")
+
+    expect(result.success).toBe(false)
+    expect(onRequestErrorSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe("Axios API Client Edge Cases", () => {
   it("should handle network errors with retries disabled", async () => {
     nock(FAKE_API_URL).get("/posts/1").replyWithError("Network Error")

--- a/src/AxiosApiClient.ts
+++ b/src/AxiosApiClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios"
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from "axios"
 
 import axiosRetry, { IAxiosRetryConfig } from "axios-retry"
 import { HeadersType, Headers } from "./headers"
@@ -13,13 +13,24 @@ type AxiosApiClientOpts = {
   retries?: number
   retryDelay?: (retryCount: number) => number
   onRetry?: (retryCount: number, error: any) => void
+  onRequest?: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>
+  onRequestError?: (error: any) => any
 }
 
 class AxiosApiClient {
   private instance: AxiosInstance
   private headers = new Headers()
 
-  constructor({ baseUrl, headers, timeout = 30000, retries = 3, retryDelay, onRetry }: AxiosApiClientOpts) {
+  constructor({
+    baseUrl,
+    headers,
+    timeout = 30000,
+    retries = 3,
+    retryDelay,
+    onRetry,
+    onRequest,
+    onRequestError,
+  }: AxiosApiClientOpts) {
     this.instance = axios.create({
       baseURL: baseUrl,
       timeout,
@@ -39,6 +50,17 @@ class AxiosApiClient {
     }
 
     axiosRetry(this.instance, retryConfig)
+
+    if (onRequest || onRequestError) {
+      this.instance.interceptors.request.use(async (config) => {
+        if (!onRequest) return config
+        try {
+          return await onRequest(config)
+        } catch (error) {
+          return onRequestError ? onRequestError(error) : Promise.reject(error)
+        }
+      }, onRequestError)
+    }
 
     this.instance.interceptors.response.use(this.successResponseHandler, this.errorResponseHandler)
   }


### PR DESCRIPTION
## Summary
- Add `onRequest` and `onRequestError` options to `AxiosApiClient`. When either is provided the client registers an axios request interceptor.
- This lets callers mutate the outgoing config (inject auth tokens, log requests, etc.) and handle interceptor errors without reaching for `getInstance()`.
- Tests cover: invocation, config mutation (header injection), and the rejected-handler path (using a second interceptor that throws to bubble up to our handler).

## Test plan
- [x] `npm run lint`
- [x] `npm test` (26/26 pass, 3 new tests added)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-level interception for the API client: allows custom transformation of outgoing requests and configurable handling of request/interceptor errors.

* **Tests**
  * Added tests for request interceptor behavior: callback invocation order, outgoing config mutation (e.g., headers), and error-handling paths when interceptors or callbacks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->