### PR TITLE
fix(package): add undici-api keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "keywords": [
     "axios-api",
+    "undici-api",
     "akadenia-api",
     "api",
     "akadenia"


### PR DESCRIPTION
Adds the "undici-api" keyword to package.json to improve discoverability of the Undici adapter support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new npm keyword to improve package discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->