### PR TITLE
fix(ci): use GH_TOKEN for release asset push

### DIFF
--- a/scripts/commit-release-assets.sh
+++ b/scripts/commit-release-assets.sh
@@ -28,5 +28,6 @@ git checkout -b $BRANCH_NAME
 git add package.json package-lock.json CHANGELOG.md
 git commit -m "chore(release): add release assets from $VERSION"
 
-# Push branch to the remote
+# Push branch to the remote using GH_TOKEN for authentication
+git remote set-url origin "https://${GH_TOKEN}@github.com/akadenia/AkadeniaAPI.git"
 git push origin $BRANCH_NAME


### PR DESCRIPTION
Updates `scripts/commit-release-assets.sh` to authenticate via HTTPS using `GH_TOKEN` instead of relying on CircleCI's read-only SSH deploy key.\n\nThis fixes the post-release step that pushes the `release/x.x.x` branch, which was failing with:\n\n```\nERROR: The key you are authenticating with has been marked as read only.\n```\n\nThe main release (tag, npm publish, GitHub release) already succeeded — this only fixes the asset-committing script.