### PR TITLE
fix: resolve JS-YAML DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,14 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.1",
+    "@types/node": "^22.x",
     "jest": "^30.4.2",
+    "js-yaml": "^5.2.0",
     "nock": "^14.0.15",
     "prettier": "^3.8.4",
     "semantic-release": "^25.0.5",
     "ts-jest": "^29.4.11",
-    "typescript": "^5.9.3",
-    "@types/node": "^22.x"
+    "typescript": "^5.9.3"
   },
   "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@22.20.0)
+      js-yaml:
+        specifier: ^5.2.0
+        version: 5.2.0
       nock:
         specifier: ^14.0.15
         version: 14.0.15
@@ -1721,6 +1724,10 @@ packages:
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  js-yaml@5.2.0:
+    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4728,6 +4735,10 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary
Update js-yaml from 3.15.0 to 5.2.0 to address Dependabot alert #86.

Resolves quadratic-complexity DoS vulnerability in merge key handling via repeated aliases.

## Test plan
- [ ] Dependabot alert #86 resolves
- [ ] Tests pass