### PR TITLE
fix(ci): consolidate release PR creation into commit-release-assets.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,39 +44,6 @@ jobs:
       - run:
           name: Semantic Release
           command: npx semantic-release
-      - run:
-          name: Create Release Assets PR
-          command: |
-            VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-            if [ -n "$VERSION" ] && git log -1 --format=%s | grep -q "chore(release)"; then
-              PAYLOAD=$(jq -n \
-                --arg title "chore(release): merge release ${VERSION} assets" \
-                --arg head "release/${VERSION}" \
-                --arg base "main" \
-                --arg body "Merge release ${VERSION} assets" \
-                '{title: $title, head: $head, base: $base, body: $body}')
-              RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-                -H "Authorization: Bearer ${GH_TOKEN}" \
-                -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls" \
-                -d "$PAYLOAD")
-              HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-              BODY=$(echo "$RESPONSE" | head -n -1)
-              if [ "$HTTP_CODE" = "201" ]; then
-                echo "Release PR created successfully."
-              elif [ "$HTTP_CODE" = "422" ]; then
-                # Only treat 422 as success if it's a duplicate PR error
-                if echo "$BODY" | grep -qi "pull request already exists"; then
-                  echo "Release PR already exists — skipping."
-                else
-                  echo "PR creation failed with unexpected 422: $BODY"
-                  exit 1
-                fi
-              else
-                echo "PR creation failed (HTTP $HTTP_CODE): $BODY"
-                exit 1
-              fi
-            fi
 
 workflows:
   ci:

--- a/scripts/commit-release-assets.sh
+++ b/scripts/commit-release-assets.sh
@@ -31,3 +31,30 @@ git commit -m "chore(release): add release assets from $VERSION"
 # Push branch to the remote using GH_TOKEN for authentication
 git remote set-url origin "https://${GH_TOKEN}@github.com/akadenia/AkadeniaAPI.git"
 git push origin $BRANCH_NAME
+
+# Create PR for release assets
+PAYLOAD=$(jq -n \
+  --arg title "chore(release): ${VERSION} assets" \
+  --arg head "$BRANCH_NAME" \
+  --arg base "main" \
+  --arg body "Automated release assets for v${VERSION}. Merging this will update \`package.json\`, \`pnpm-lock.yaml\`, and \`CHANGELOG.md\` on main." \
+  '{title: $title, head: $head, base: $base, body: $body}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls" \
+  -d "$PAYLOAD")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+
+if [ "$HTTP_CODE" = "201" ]; then
+  PR_URL=$(echo "$BODY" | jq -r '.html_url')
+  echo "Release PR created: $PR_URL"
+elif [ "$HTTP_CODE" = "422" ] && echo "$BODY" | grep -qi "pull request already exists"; then
+  echo "Release PR already exists — skipping."
+else
+  echo "PR creation failed (HTTP $HTTP_CODE): $BODY"
+  exit 1
+fi


### PR DESCRIPTION
Moves the release assets PR creation from a separate CircleCI step into \ to eliminate the race condition where the CircleCI step would attempt to create a PR before the branch was visible on the remote.